### PR TITLE
初期再生速度の設定に対応

### DIFF
--- a/lib/configurations/video_player_configuration.dart
+++ b/lib/configurations/video_player_configuration.dart
@@ -36,6 +36,9 @@ class VideoPlayerConfiguration {
 
   final bool hidesControls;
 
+  ///The playback speed rate at which the video will start
+  final double initialPlayBackSpeedRate;
+
   VideoPlayerConfiguration({
     this.aspectRatio,
     this.autoPlay = false,
@@ -53,6 +56,7 @@ class VideoPlayerConfiguration {
     this.controlsConfiguration = const VideoPlayerControlsConfiguration(),
     this.quarityTrackSelectable,
     this.hidesControls = false,
+    this.initialPlayBackSpeedRate = 1.0,
   });
 
   VideoPlayerConfiguration copyWith({
@@ -67,6 +71,7 @@ class VideoPlayerConfiguration {
     VideoPlayerControlsConfiguration? controlsConfiguration,
     bool? hidesControls,
     bool? remoteControlEnable,
+    double? initialPlayBackSpeedRate,
   }) {
     return VideoPlayerConfiguration(
       autoPlay: autoPlay ?? this.autoPlay,
@@ -84,6 +89,8 @@ class VideoPlayerConfiguration {
       controlsConfiguration:
           controlsConfiguration ?? this.controlsConfiguration,
       hidesControls: hidesControls ?? this.hidesControls,
+      initialPlayBackSpeedRate:
+          initialPlayBackSpeedRate ?? this.initialPlayBackSpeedRate,
     );
   }
 }

--- a/lib/controller/video_player_controller.dart
+++ b/lib/controller/video_player_controller.dart
@@ -32,6 +32,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   VideoPlayerController({
     required this.configuration,
     VideoPlayerDataSource? dataSource,
+    this.initialPlayBackSpeedRate = 1.0,
   }) : super(VideoPlayerValue()) {
     _create();
     if (dataSource != null) _setDataSource(dataSource);
@@ -52,6 +53,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   late Completer<void> _initializeCompleter;
 
   final Completer<void> _createCompleter = Completer<void>();
+
+  final double initialPlayBackSpeedRate;
 
   final VideoPlayerSubtitlesController subtitlesController =
       VideoPlayerSubtitlesController();
@@ -97,6 +100,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     _textureId =
         await VideoPlayerPlatform.instance.create(bufferingConfiguration);
     tracksController.textureId = _textureId;
+    setPlaybackRate(initialPlayBackSpeedRate);
     _createCompleter.complete(null);
 
     void eventListener(PlatformEvent event) {
@@ -329,7 +333,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   void expand() {
-    if (!value.initialized || _isDisposed || !value.isFullscreen || value.isExpanded) return;
+    if (!value.initialized ||
+        _isDisposed ||
+        !value.isFullscreen ||
+        value.isExpanded) return;
     VideoPlayerPlatform.instance.expand(_textureId);
     value = value.copyWith(
       eventType: VideoPlayerEventType.expandChanged,
@@ -338,7 +345,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   void shrink() {
-    if (!value.initialized || _isDisposed || !value.isFullscreen || !value.isExpanded) return;
+    if (!value.initialized ||
+        _isDisposed ||
+        !value.isFullscreen ||
+        !value.isExpanded) return;
     VideoPlayerPlatform.instance.shrink(_textureId);
     value = value.copyWith(
       eventType: VideoPlayerEventType.expandChanged,

--- a/lib/controller/video_player_controller.dart
+++ b/lib/controller/video_player_controller.dart
@@ -32,7 +32,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   VideoPlayerController({
     required this.configuration,
     VideoPlayerDataSource? dataSource,
-    this.initialPlayBackSpeedRate = 1.0,
   }) : super(VideoPlayerValue()) {
     _create();
     if (dataSource != null) _setDataSource(dataSource);
@@ -53,8 +52,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   late Completer<void> _initializeCompleter;
 
   final Completer<void> _createCompleter = Completer<void>();
-
-  final double initialPlayBackSpeedRate;
 
   final VideoPlayerSubtitlesController subtitlesController =
       VideoPlayerSubtitlesController();
@@ -100,7 +97,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     _textureId =
         await VideoPlayerPlatform.instance.create(bufferingConfiguration);
     tracksController.textureId = _textureId;
-    setPlaybackRate(initialPlayBackSpeedRate);
+    setPlaybackRate(configuration.initialPlayBackSpeedRate);
     _createCompleter.complete(null);
 
     void eventListener(PlatformEvent event) {


### PR DESCRIPTION
Notionタスク：[前の動画の再生速度を固定する](https://www.notion.so/0487274d8f9349669948388af9aa37a0?pvs=4)

再生速度の設定値をFlutter側からInputするために、VideoPlayerController()のコンストラクタに初期速度値を追加するPRです。

当初はVideoPlayer内で再生速度設定の固定化を閉じようとしましたが、VideoPlayerControllerのインスタンスが各動画ごとに生成される設計になっているため、閉じることができず、外（flutter）からinputする必要がありこのようにしています。