### PR TITLE
字幕変更がユーザアクションかシステム制御かわかるようにする

### DIFF
--- a/lib/controls/more_button.dart
+++ b/lib/controls/more_button.dart
@@ -226,7 +226,8 @@ class MoreButtonState extends VideoPlayerControllerState<MoreButton> {
     return MaterialClickableWidget(
       onTap: () {
         Navigator.of(context).pop();
-        controller.subtitlesController.setSubtitleSource(index);
+        controller.subtitlesController
+            .setSubtitleSource(index, isUserAction: true);
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),

--- a/lib/subtitles/video_player_subtitles_controller.dart
+++ b/lib/subtitles/video_player_subtitles_controller.dart
@@ -11,7 +11,8 @@ import 'video_player_subtitles_source_type.dart';
 enum SubtitlesStreamEvent {
   didReset,
   sourceListChanged,
-  selectedSourceChanged,
+  userSelectedSourceChanged,
+  systemSelectedSourceChanged,
 }
 
 class VideoPlayerSubtitlesController {
@@ -90,7 +91,7 @@ class VideoPlayerSubtitlesController {
     setSubtitleSource(index);
   }
 
-  void setSubtitleSource(int index) {
+  void setSubtitleSource(int index, {bool isUserAction = false}) {
     _subtitlesLines = [];
     if (-1 < index && index < subtitlesSourceList.length) {
       _selectedSubtitlesSourceIndex = index;
@@ -101,7 +102,13 @@ class VideoPlayerSubtitlesController {
     } else {
       _selectedSubtitlesSourceIndex = null;
     }
-    _subtitlesStreamController.add(SubtitlesStreamEvent.selectedSourceChanged);
+    if (isUserAction) {
+      _subtitlesStreamController
+          .add(SubtitlesStreamEvent.userSelectedSourceChanged);
+    } else {
+      _subtitlesStreamController
+          .add(SubtitlesStreamEvent.systemSelectedSourceChanged);
+    }
   }
 
   void loadAllSubtitleLines() async {

--- a/lib/subtitles/video_player_subtitles_drawer.dart
+++ b/lib/subtitles/video_player_subtitles_drawer.dart
@@ -77,7 +77,8 @@ class _VideoPlayerSubtitlesDrawerState
         break;
       case SubtitlesStreamEvent.sourceListChanged:
         break;
-      case SubtitlesStreamEvent.selectedSourceChanged:
+      case SubtitlesStreamEvent.systemSelectedSourceChanged:
+      case SubtitlesStreamEvent.userSelectedSourceChanged:
         if (controller.subtitlesController.selectedSubtitlesSource
                     ?.asmsIsSegmented ==
                 true &&


### PR DESCRIPTION
## Notionタスク
[字幕設定保持](https://www.notion.so/1965514ff64c43d29afef08f04cd13f1?pvs=4)

##背景
ユーザ操作による字幕変更は変更後の値をローカルでバックアップしたい

## As-Is
字幕設定変更通知がユーザ操作かシステム決定によるものかどうかが不明

## To-Be
字幕設定変更がユーザ操作かシステム決定によるものかどうかがわかる

## 関連PR
https://github.com/Samantha-shorts/Flutter/pull/190