### PR TITLE
VideoPlayerにinDisposeを追加

### DIFF
--- a/lib/player/video_player.dart
+++ b/lib/player/video_player.dart
@@ -11,10 +11,12 @@ class VideoPlayer extends StatefulWidget {
     Key? key,
     required this.controller,
     this.noProvider = false,
+    this.onDispose,
   }) : super(key: key);
 
   final VideoPlayerController controller;
   final bool noProvider;
+  final VoidCallback? onDispose;
 
   @override
   State<VideoPlayer> createState() {
@@ -77,6 +79,8 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   @override
   void dispose() {
+    widget.onDispose?.call();
+
     if (_isFullscreen) {
       _navigatorState.maybePop();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,


### PR DESCRIPTION
## Notion
https://www.notion.so/HOME-ce9732f6da044c4f8a375cbb7816b12a?pvs=4

## 背景
上記タスクにて、プレイヤーを閉じた際にHOME画面のサムネイル上の赤いバーを最新値に更新したいです。
そのために、プレイヤーのインスタンスがdiposeされたタイミングでとあるAPIをコールするような処理にしたく、
onDisposeをVideoPlayerウィジェットに追加したいです。