### PR TITLE
バッファ時間の変更

### DIFF
--- a/lib/configurations/video_player_buffering_configuration.dart
+++ b/lib/configurations/video_player_buffering_configuration.dart
@@ -3,8 +3,8 @@
 class VideoPlayerBufferingConfiguration {
   ///Constants values are from the offical exoplayer documentation
   ///https://exoplayer.dev/doc/reference/constant-values.html#com.google.android.exoplayer2.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS
-  static const defaultMinBufferMs = 25000;
-  static const defaultMaxBufferMs = 6553600;
+  static const defaultMinBufferMs = 10000;
+  static const defaultMaxBufferMs = 100000;
   static const defaultBufferForPlaybackMs = 3000;
   static const defaultBufferForPlaybackAfterRebufferMs = 6000;
 


### PR DESCRIPTION
Android端末でメモリリークするようになった。

バッファ時間が長すぎたので、対策の一つとして短縮するように変更