### PR TITLE
バッファ制御の処理を実装

### DIFF
--- a/android/src/main/kotlin/matsune/video_player/VideoPlayer.kt
+++ b/android/src/main/kotlin/matsune/video_player/VideoPlayer.kt
@@ -107,6 +107,12 @@ class VideoPlayer(
                     if (exoPlayer.isPlaying) {
                         sendPositionChanged()
                     }
+                    val bufferedPosition = exoPlayer.bufferedPosition
+                    if (bufferedPosition != lastSendBufferedPosition) {
+                        val range: List<Number?> = listOf(0, bufferedPosition)
+                        sendEvent(EVENT_BUFFER_CHANGED, mapOf("bufferRange" to range))
+                        lastSendBufferedPosition = bufferedPosition
+                    }
                     handler.postDelayed(this, 200)
                 }
             }
@@ -148,15 +154,7 @@ class VideoPlayer(
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     when (playbackState) {
                         Player.STATE_BUFFERING -> {
-                            val bufferedPosition = exoPlayer.bufferedPosition ?: 0L
-                            if (bufferedPosition != lastSendBufferedPosition) {
-                                val range: List<Number?> = listOf(0, bufferedPosition)
-                                sendEvent(
-                                    EVENT_BUFFER_CHANGED,
-                                    mapOf("bufferRange" to listOf(range))
-                                )
-                                lastSendBufferedPosition = bufferedPosition
-                            }
+                            // no-op
                         }
                         Player.STATE_READY -> {
                             if (!isInitialized) {

--- a/ios/Classes/VideoPlayer.swift
+++ b/ios/Classes/VideoPlayer.swift
@@ -150,6 +150,7 @@ class VideoPlayer: NSObject {
     func setDataSource(url: URL, headers: [String: String]?) {
         let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": headers ?? [:]])
         let item = AVPlayerItem(asset: asset)
+        item.preferredForwardBufferDuration = 100 
         item.add(videoOutput)
         player.replaceCurrentItem(with: item)
         if let group = asset.mediaSelectionGroup(forMediaCharacteristic: .legible) {

--- a/lib/configurations/video_player_buffering_configuration.dart
+++ b/lib/configurations/video_player_buffering_configuration.dart
@@ -3,10 +3,14 @@
 class VideoPlayerBufferingConfiguration {
   ///Constants values are from the offical exoplayer documentation
   ///https://exoplayer.dev/doc/reference/constant-values.html#com.google.android.exoplayer2.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS
-  static const defaultMinBufferMs = 25000;
-  static const defaultMaxBufferMs = 1800000;
-  static const defaultBufferForPlaybackMs = 3000;
-  static const defaultBufferForPlaybackAfterRebufferMs = 6000;
+  //常に確保しようとするバッファ量:30秒
+  static const defaultMinBufferMs = 30000;
+  //最大バッファ量:100秒
+  static const defaultMaxBufferMs = 100000;
+  //再生開始時に必要なバッファ量:10秒
+  static const defaultBufferForPlaybackMs = 10000;
+  //再生停止した場合時に再開するのに必要なバッファ量:10秒
+  static const defaultBufferForPlaybackAfterRebufferMs = 10000;
 
   /// The default minimum duration of media that the player will attempt to
   /// ensure is buffered at all times, in milliseconds.

--- a/lib/configurations/video_player_buffering_configuration.dart
+++ b/lib/configurations/video_player_buffering_configuration.dart
@@ -3,8 +3,8 @@
 class VideoPlayerBufferingConfiguration {
   ///Constants values are from the offical exoplayer documentation
   ///https://exoplayer.dev/doc/reference/constant-values.html#com.google.android.exoplayer2.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS
-  //常に確保しようとするバッファ量:30秒
-  static const defaultMinBufferMs = 30000;
+  //再生が進んでも常に確保しようとするバッファ量:60秒
+  static const defaultMinBufferMs = 60000;
   //最大バッファ量:100秒
   static const defaultMaxBufferMs = 100000;
   //再生開始時に必要なバッファ量:10秒


### PR DESCRIPTION
↓これら2つのチケットで共通して必要な実装
https://www.notion.so/UX-18b134ccdf22802b80eaee5c8a05d153?pvs=4
https://www.notion.so/5f0c97420d334453984f6a3a5d0e12d3?pvs=4

↓バッファについて整理したメモ
https://www.notion.so/6791342aa04c48058d286387b810f34a?pvs=4

これまでAndroidでは最新のバッファ量がflutterに送られてきていなかったので、送れるように修正。