### PR TITLE
バッファ中のローディング表示の不具合修正

### DIFF
--- a/android/src/main/kotlin/matsune/video_player/VideoPlayer.kt
+++ b/android/src/main/kotlin/matsune/video_player/VideoPlayer.kt
@@ -55,6 +55,8 @@ class VideoPlayer(
 
     private var handler = Handler(Looper.getMainLooper())
     private val runnable: Runnable
+    private val bufferingRunnable: Runnable
+
 
     private var playerNotificationManager: PlayerNotificationManager? = null
     private var refreshHandler: Handler? = null
@@ -64,6 +66,7 @@ class VideoPlayer(
     private val workManager: WorkManager
     private val workerObserverMap: HashMap<UUID, Observer<WorkInfo?>>
     var disableRemoteControl: Boolean = false
+    private var isBufferingRunnableStarted = false
 
     var isMuted: Boolean
         get() = exoPlayer.volume == 0f
@@ -108,6 +111,12 @@ class VideoPlayer(
                     if (exoPlayer.isPlaying) {
                         sendPositionChanged()
                     }
+                    handler.postDelayed(this, 200)
+                }
+            }
+        bufferingRunnable =
+            object : Runnable {
+                override fun run() {
                     val bufferedPosition = exoPlayer.bufferedPosition
                     if (bufferedPosition != lastSendBufferedPosition) {
                         val range: List<Number?> = listOf(0, bufferedPosition)
@@ -123,6 +132,8 @@ class VideoPlayer(
         disposeMediaSession()
         disposeRemoteNotifications()
         handler.removeCallbacks(runnable)
+        handler.removeCallbacks(bufferingRunnable)
+        isBufferingRunnableStarted = false
         if (isInitialized) {
             exoPlayer.stop()
         }
@@ -194,6 +205,11 @@ class VideoPlayer(
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     if (isPlaying) {
                         handler.post(runnable)
+
+                        if (!isBufferingRunnableStarted) {
+                            handler.post(bufferingRunnable)
+                            isBufferingRunnableStarted = true
+                        }
                     } else {
                         handler.removeCallbacks(runnable)
                     }

--- a/lib/controller/video_player_controller.dart
+++ b/lib/controller/video_player_controller.dart
@@ -131,24 +131,18 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           updateLoadingState();
           break;
         case PlatformEventType.positionChanged:
-          // if (_onSeeking) {
-          // print('[check]positionChanged (_onSeeking) ${_onSeeking}');
-          // print('[check]positionChanged (current position) ${event.position}');
-          // }
           if (_onSeeking && _positionChangedOnSeekingCount == 0) {
             _positionChangedOnSeekingCount++;
           } else if (_onSeeking && _positionChangedOnSeekingCount > 0) {
             _onSeeking = false;
             _positionChangedOnSeekingCount = 0;
           }
-
           value = value.copyWith(
             eventType: VideoPlayerEventType.positionChanged,
             position: event.position,
           );
           break;
         case PlatformEventType.bufferChanged:
-          print('buffered: ${value.buffered?.end}');
           value = value.copyWith(
             eventType: VideoPlayerEventType.bufferChanged,
             buffered: event.buffered,

--- a/lib/controls/material_controls.dart
+++ b/lib/controls/material_controls.dart
@@ -453,7 +453,8 @@ class _SkipBackButtonState extends VideoPlayerControllerState<_SkipBackButton> {
                     milliseconds:
                         controlsConfiguration.backwardSkipTimeInMilliseconds))
             .inMilliseconds;
-        controller.seekTo(Duration(milliseconds: max(skip, beginning)));
+        controller.seekTo(Duration(milliseconds: max(skip, beginning)),
+            isUserTrigger: true);
         widget.onClicked();
         controller.controlsEventStreamController
             .add(ControlsEvent(eventType: ControlsEventType.onTapSkipBack));
@@ -492,7 +493,8 @@ class _SkipForwardButtonState
                       controlsConfiguration.forwardSkipTimeInMilliseconds,
                 ))
             .inMilliseconds;
-        controller.seekTo(Duration(milliseconds: min(skip, end)));
+        controller.seekTo(Duration(milliseconds: min(skip, end)),
+            isUserTrigger: true);
         widget.onClicked();
         controller.controlsEventStreamController
             .add(ControlsEvent(eventType: ControlsEventType.onTapSkipForward));
@@ -519,7 +521,7 @@ class _ReplayButtonState extends VideoPlayerControllerState<_ReplayButton> {
     return MaterialClickableWidget(
       onTap: () async {
         if (lastValue?.isPlaying == true) {
-          controller.pause();
+          controller.pause(isUserAction: true);
           controller.controlsEventStreamController
               .add(ControlsEvent(eventType: ControlsEventType.onTapPause));
         } else if (lastValue?.isFinished == true) {

--- a/lib/controls/material_video_progress_bar.dart
+++ b/lib/controls/material_video_progress_bar.dart
@@ -44,7 +44,7 @@ class _VideoProgressBarState
         if (controller.value.initialized != true) {
           return;
         }
-        await controller.seekTo(_seekingPosition);
+        await controller.seekTo(_seekingPosition, isUserTrigger: true);
         _seekingPosition = null;
         widget.dragEnd?.call();
       },

--- a/lib/controls/play_pause_button.dart
+++ b/lib/controls/play_pause_button.dart
@@ -15,7 +15,7 @@ class PlayPauseButtonState extends VideoPlayerControllerState<PlayPauseButton> {
     return MaterialClickableWidget(
       onTap: () async {
         if (lastValue?.isPlaying == true) {
-          controller.pause();
+          controller.pause(isUserAction: true);
           controller.controlsEventStreamController
               .add(ControlsEvent(eventType: ControlsEventType.onTapPause));
         } else if (lastValue?.isFinished == true) {


### PR DESCRIPTION
xhttps://www.notion.so/UX-18b134ccdf22802b80eaee5c8a05d153?pvs=4#197134ccdf228081acc7ccfca0c7ef85

上記チケットにおけるのfeedback指摘への対応です
同様にflutter側レポジトリへも対策を入れています

## 指摘1
### 現象
実は再生できる状態なのにローディングされてしてしまう。おそらくバッファを取得し終わっているはずだが、プレイヤー左下の再生ボタンを自分で押さない限り自動では再生が再開しない

### 原因
kotlinにて、バッファ状況をflutterに送信する定期実行処理が、再生停止とともに停止していたため、再生停止中にバッファ取得で
きていてもflutter側でバッファ状況を得ることができず再生再開しないようになっていた。

### 対策
定期実行処理が再生停止時に、一時停止しないように修正した。

### 動作確認
https://github.com/user-attachments/assets/33d718bd-2a75-4a10-a65a-a567c9bbebaa



## 指摘2
### 現象
最大バッファより先にシークエンスバーを動かすと、プレイヤーがバグってしまう。シークエンスバーを後に戻すと、プレイヤーは元に戻る

### 原因
シーク動作後に、現在地点とバッファ地点の差が10秒以上開きがあると再生する実装になっている。
一方、シーク動作をすると、シーク動作前にイベント発生している現在地点通知が遅れて通知が来る。
そのため、実際にはシーク先に現在地点があるものの、シーク前の現在地点に対して、バッファ地点との比較を行ってしまい、10秒以上開きがある場合にplay()を要求するが、まだ実際はバッファが10秒以上も確保できていないので再生ができずシステム側で再生停止する。
このplay()要求と再生停止が繰り返されることでチケットにあるような動きになってしまっていた。

### 対策
シーク動作後、1回目の現在地点通知を無視するようにした。

### 動作確認
https://github.com/user-attachments/assets/4dd1de68-d607-4ebc-a73a-2ef791d8a809

## 指摘3
### 現象
動画を停止しても、勝手に再生が始まる

### 原因
「再生停止中に10秒のバッファが取得できると再生開始する」というロジックを入れていたため。

### 対策
停止の理由がシステムトリガーなのか、ユーザアクションなのかを区別し、ユーザアクションの場合はバッファが溜まっても再生再開しないようにした。

### 動作確認
https://github.com/user-attachments/assets/4dd1de68-d607-4ebc-a73a-2ef791d8a809

