### PR TITLE
バッファ時間を制御する仕組みをrevertする

### DIFF
--- a/lib/configurations/video_player_buffering_configuration.dart
+++ b/lib/configurations/video_player_buffering_configuration.dart
@@ -1,9 +1,5 @@
 ///Configuration class used to setup better buffering experience or setup custom
 ///load settings. Currently used only in Android.
-
-///再生開始時、バッファ不足での停止後の再生再開に必要なバッファ量:10秒
-const defaultBufferForPlaybackMs = 10000;
-
 class VideoPlayerBufferingConfiguration {
   ///Constants values are from the offical exoplayer documentation
   ///https://exoplayer.dev/doc/reference/constant-values.html#com.google.android.exoplayer2.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS
@@ -11,6 +7,10 @@ class VideoPlayerBufferingConfiguration {
   static const defaultMinBufferMs = 60000;
   //最大バッファ量:100秒
   static const defaultMaxBufferMs = 100000;
+  //再生開始時に必要なバッファ量:10秒
+  static const defaultBufferForPlaybackMs = 10000;
+  //再生停止した場合時に再開するのに必要なバッファ量:10秒
+  static const defaultBufferForPlaybackAfterRebufferMs = 10000;
 
   /// The default minimum duration of media that the player will attempt to
   /// ensure is buffered at all times, in milliseconds.
@@ -33,6 +33,7 @@ class VideoPlayerBufferingConfiguration {
     this.minBufferMs = defaultMinBufferMs,
     this.maxBufferMs = defaultMaxBufferMs,
     this.bufferForPlaybackMs = defaultBufferForPlaybackMs,
-    this.bufferForPlaybackAfterRebufferMs = defaultBufferForPlaybackMs,
+    this.bufferForPlaybackAfterRebufferMs =
+        defaultBufferForPlaybackAfterRebufferMs,
   });
 }

--- a/lib/controller/video_player_controller.dart
+++ b/lib/controller/video_player_controller.dart
@@ -118,7 +118,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
             eventType: VideoPlayerEventType.isPlayingChanged,
             isPlaying: event.isPlaying,
           );
-          updateLoadingState();
           break;
         case PlatformEventType.positionChanged:
           value = value.copyWith(
@@ -301,35 +300,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return;
     }
     subtitlesController.loadAllSubtitleLines();
-  }
-
-  void updateLoadingState() {
-    if (value.isLoading || value.isPlaying) {
-      value = value.copyWith(isLoading: false);
-    } else if (!value.isLoading && !value.isPlaying && checkBuffering()) {
-      value = value.copyWith(isLoading: true);
-    }
-  }
-
-  /// [true]:buffering, [false]:not buffering
-  bool checkBuffering() {
-    if (!value.initialized || _isDisposed || value.isFinished) {
-      return false;
-    }
-    if (value.buffered == null || value.duration == null) {
-      return true;
-    }
-    if (value.duration! - value.buffered!.end < Duration(seconds: 1)) {
-      return false;
-    }
-    if (value.duration! - value.position < Duration(seconds: 1)) {
-      return false;
-    }
-    if (value.buffered!.end - value.position <
-        const Duration(milliseconds: defaultBufferForPlaybackMs)) {
-      return true;
-    }
-    return false;
   }
 
   Future<void> play() async {

--- a/lib/controller/video_player_controller.dart
+++ b/lib/controller/video_player_controller.dart
@@ -49,16 +49,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   bool _isDisposed = false;
 
-  bool _isPausingByUserAction = false;
-
-  bool get isPausingByUserAction => _isPausingByUserAction;
-
-  bool _onSeeking = false;
-
-  bool get onSeeking => _onSeeking;
-
-  int _positionChangedOnSeekingCount = 0;
-
   late Completer<void> _initializeCompleter;
 
   final Completer<void> createCompleter = Completer<void>();
@@ -131,12 +121,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           updateLoadingState();
           break;
         case PlatformEventType.positionChanged:
-          if (_onSeeking && _positionChangedOnSeekingCount == 0) {
-            _positionChangedOnSeekingCount++;
-          } else if (_onSeeking && _positionChangedOnSeekingCount > 0) {
-            _onSeeking = false;
-            _positionChangedOnSeekingCount = 0;
-          }
           value = value.copyWith(
             eventType: VideoPlayerEventType.positionChanged,
             position: event.position,
@@ -350,22 +334,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   Future<void> play() async {
     if (!value.initialized || _isDisposed || value.isPlaying) return;
-    _isPausingByUserAction = false;
     await VideoPlayerPlatform.instance.play(textureId);
   }
 
-  Future<void> pause({bool isUserAction = false}) async {
+  Future<void> pause() async {
     if (!value.initialized || _isDisposed || !value.isPlaying) return;
-    _isPausingByUserAction = isUserAction;
     await VideoPlayerPlatform.instance.pause(textureId);
   }
 
-  Future<void> seekTo(Duration? position, {bool isUserTrigger = false}) async {
+  Future<void> seekTo(Duration? position) async {
     if (!value.initialized || _isDisposed || position == null) {
       return;
-    }
-    if (isUserTrigger) {
-      _onSeeking = true;
     }
     Duration? positionToSeek = position;
     if (position > value.duration!) {

--- a/lib/controller/video_player_value.dart
+++ b/lib/controller/video_player_value.dart
@@ -35,7 +35,6 @@ class VideoPlayerValue {
     this.errorDetails,
     this.invalid,
     this.errorCode,
-    this.isLoading = false,
   });
 
   VideoPlayerEventType? eventType;
@@ -77,8 +76,6 @@ class VideoPlayerValue {
 
   final int? errorCode;
 
-  final bool isLoading;
-
   bool get initialized => duration != null;
 
   bool get isFinished => position.inSeconds == duration?.inSeconds;
@@ -101,7 +98,6 @@ class VideoPlayerValue {
     String? errorDetails,
     bool? invalid,
     int? errorCode,
-    bool? isLoading,
   }) {
     return VideoPlayerValue(
       eventType: eventType ?? this.eventType,
@@ -119,7 +115,6 @@ class VideoPlayerValue {
       errorDetails: errorDetails ?? this.errorDetails,
       invalid: invalid ?? this.invalid,
       errorCode: errorCode ?? this.errorCode,
-      isLoading: isLoading ?? this.isLoading,
     );
   }
 
@@ -139,9 +134,8 @@ class VideoPlayerValue {
         'isExpanded: $isExpanded, '
         'buffered: ${buffered ?? '[]'}, '
         'errorDescription: $errorDescription, '
-        'errorDetails: $errorDetails, '
-        'invalid: $invalid, '
-        'errorCode: $errorCode, '
-        'isLoading: $isLoading), ';
+        'errorDetails: $errorDetails), '
+        'invalid: $invalid), '
+        'errorCode: $errorCode)';
   }
 }

--- a/lib/controls/material_controls.dart
+++ b/lib/controls/material_controls.dart
@@ -453,8 +453,7 @@ class _SkipBackButtonState extends VideoPlayerControllerState<_SkipBackButton> {
                     milliseconds:
                         controlsConfiguration.backwardSkipTimeInMilliseconds))
             .inMilliseconds;
-        controller.seekTo(Duration(milliseconds: max(skip, beginning)),
-            isUserTrigger: true);
+        controller.seekTo(Duration(milliseconds: max(skip, beginning)));
         widget.onClicked();
         controller.controlsEventStreamController
             .add(ControlsEvent(eventType: ControlsEventType.onTapSkipBack));
@@ -493,8 +492,7 @@ class _SkipForwardButtonState
                       controlsConfiguration.forwardSkipTimeInMilliseconds,
                 ))
             .inMilliseconds;
-        controller.seekTo(Duration(milliseconds: min(skip, end)),
-            isUserTrigger: true);
+        controller.seekTo(Duration(milliseconds: min(skip, end)));
         widget.onClicked();
         controller.controlsEventStreamController
             .add(ControlsEvent(eventType: ControlsEventType.onTapSkipForward));
@@ -521,7 +519,7 @@ class _ReplayButtonState extends VideoPlayerControllerState<_ReplayButton> {
     return MaterialClickableWidget(
       onTap: () async {
         if (lastValue?.isPlaying == true) {
-          controller.pause(isUserAction: true);
+          controller.pause();
           controller.controlsEventStreamController
               .add(ControlsEvent(eventType: ControlsEventType.onTapPause));
         } else if (lastValue?.isFinished == true) {

--- a/lib/controls/material_controls.dart
+++ b/lib/controls/material_controls.dart
@@ -8,9 +8,7 @@ import 'package:video_player/utils.dart';
 import 'package:video_player/controls/expand_shrink_button.dart';
 
 class MaterialControls extends StatefulWidget {
-  const MaterialControls({Key? key, required this.isLoading}) : super(key: key);
-
-  final bool isLoading;
+  const MaterialControls({Key? key}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _MaterialControlsState();
@@ -216,11 +214,7 @@ class _MaterialControlsState
               },
             ),
           ),
-          Expanded(
-            child: widget.isLoading
-                ? const SizedBox.expand()
-                : const _ReplayButton(),
-          ),
+          const Expanded(child: _ReplayButton()),
           Expanded(
             child: _SkipForwardButton(
               onClicked: () {

--- a/lib/controls/material_video_progress_bar.dart
+++ b/lib/controls/material_video_progress_bar.dart
@@ -44,7 +44,7 @@ class _VideoProgressBarState
         if (controller.value.initialized != true) {
           return;
         }
-        await controller.seekTo(_seekingPosition, isUserTrigger: true);
+        await controller.seekTo(_seekingPosition);
         _seekingPosition = null;
         widget.dragEnd?.call();
       },

--- a/lib/controls/play_pause_button.dart
+++ b/lib/controls/play_pause_button.dart
@@ -15,7 +15,7 @@ class PlayPauseButtonState extends VideoPlayerControllerState<PlayPauseButton> {
     return MaterialClickableWidget(
       onTap: () async {
         if (lastValue?.isPlaying == true) {
-          controller.pause(isUserAction: true);
+          controller.pause();
           controller.controlsEventStreamController
               .add(ControlsEvent(eventType: ControlsEventType.onTapPause));
         } else if (lastValue?.isFinished == true) {

--- a/lib/fullscreen/fullscreen_video_page.dart
+++ b/lib/fullscreen/fullscreen_video_page.dart
@@ -6,9 +6,7 @@ import 'package:video_player/controller/video_player_value.dart';
 import 'package:video_player/player/video_player_with_controls.dart';
 
 class FullscreenVideoPage extends StatefulWidget {
-  const FullscreenVideoPage({super.key, required this.isLoading});
-
-  final bool isLoading;
+  const FullscreenVideoPage({super.key});
 
   @override
   State<FullscreenVideoPage> createState() => FullscreenVideoPageState();
@@ -54,7 +52,6 @@ class FullscreenVideoPageState
   Widget _buildPlayer() {
     return VideoPlayerWithControls(
       controller: controller,
-      isLoading: widget.isLoading,
     );
   }
 }

--- a/lib/player/video_player.dart
+++ b/lib/player/video_player.dart
@@ -58,8 +58,6 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   bool _isFullscreen = false;
 
-  bool _isLoading = false;
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -113,11 +111,6 @@ class _VideoPlayerState extends State<VideoPlayer> {
         await exitFullscreen();
       }
     }
-    if (_isLoading != widget.controller.value.isLoading) {
-      setState(() {
-        _isLoading = widget.controller.value.isLoading;
-      });
-    }
   }
 
   @override
@@ -167,7 +160,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
       builder: (BuildContext context, Widget? child) {
         return VideoPlayerControllerProvider(
           controller: widget.controller,
-          child: FullscreenVideoPage(isLoading: _isLoading),
+          child: const FullscreenVideoPage(),
         );
       },
     );
@@ -187,6 +180,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   Widget _buildPlayer() {
     return VideoPlayerWithControls(
-        controller: widget.controller, isLoading: _isLoading);
+      controller: widget.controller,
+    );
   }
 }

--- a/lib/player/video_player_with_controls.dart
+++ b/lib/player/video_player_with_controls.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:video_player/controller/controller.dart';
 import 'package:video_player/controls/controls.dart';
 import 'package:video_player/platform/platform.dart';
@@ -7,12 +6,10 @@ import 'package:video_player/subtitles/subtitles.dart';
 
 class VideoPlayerWithControls extends StatefulWidget {
   final VideoPlayerController? controller;
-  final bool isLoading;
 
   const VideoPlayerWithControls({
     Key? key,
     this.controller,
-    required this.isLoading,
   }) : super(key: key);
 
   @override
@@ -52,9 +49,7 @@ class VideoPlayerWithControlsState extends State<VideoPlayerWithControls> {
         _Player(controller: videoPlayerController),
         const VideoPlayerSubtitlesDrawer(),
         if (widget.controller?.configuration.hidesControls != true)
-          MaterialControls(isLoading: widget.isLoading),
-        if (widget.isLoading)
-          const IgnorePointer(child: Center(child: CircularProgressIndicator()))
+          const MaterialControls(),
       ],
     );
   }


### PR DESCRIPTION
## 背景
「バッファ情報に応じてローディング表示を行う」という仕様に応じた実装を行なっていたが、本来ネイティブに任すのが設計的に良いが、無理やりローディングの制御をしている形になっていたので案の定バグが出てしまった

## 対応
当該コミットをrevertする。
一方で、バッファ情報を取得してflutter側に渡してあげるのは必要なので残しておく。
（元々Androidではflutterにバッファ情報を渡せていなかった）